### PR TITLE
Update readme for opencv 3 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ documentation](https://docs.opencv.org/3.4.6/) as well.
 
 The following external dependencies are required:
 - python2.7
-- opencv
+- opencv 3.4.6 (other 3.4 versions may work, but development is done
+  against this version)
 
 OpenCV is a complicated dependency with a lot of different
 configurations that can break this crate since it relies on fragile
@@ -35,9 +36,9 @@ opencv_version
 
 ### Install OpenCV
 
-Install opencv 3.4.6 (other versions of 3.4.6 may work too, but
-development is done against 3.4.6). Check your platform's package
-manager or see the upstream opencv [installation guides](https://docs.opencv.org/3.4/df/d65/tutorial_table_of_content_introduction.html).
+Install opencv 3.4.6. Check your platform's package manager or see the
+upstream opencv
+[installation guides](https://docs.opencv.org/3.4/df/d65/tutorial_table_of_content_introduction.html).
 
 ### Compiling OpenCV
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,73 @@
-Quick update: this crate has been updated to work with OpenCV 3.4.6, some of
-the following doc is outdated:
+# Rust OpenCV bindings
 
+[![Build Status](https://travis-ci.org/twistedfall/opencv-rust.svg?branch=master)](https://travis-ci.org/twistedfall/opencv-rust)
+[![docs.rs](https://docs.rs/opencv/badge.svg)](https://docs.rs/opencv)
+
+Experimental Rust bindings for OpenCV 3.
+
+The API is usable but unstable and not very battle-tested; use at your own risk.
+
+## API Docs
+
+[API Documentation](https://docs.rs/opencv) is, to varying success,
+translated from OpenCV's doxygen docs. Most likely you'll want to
+refer to the official [OpenCV C++
+documentation](https://docs.opencv.org/3.4.6/) as well.
+
+## Getting Started
+
+The following external dependencies are required:
+- python2.7
+- opencv
+
+OpenCV is a complicated dependency with a lot of different
+configurations that can break this crate since it relies on fragile
+header parsing. Try these strategies in order, continuing to the next
+if builds with this crate fail.
+
+### See if you already have the right version of OpenCV installed
+
+if opencv is installed, its version can be checked with:
+
+```sh
+opencv_version
+```
+
+### Install OpenCV
+
+Install opencv 3.4.6 (other versions of 3.4.6 may work too, but
+development is done against 3.4.6). Check your platform's package
+manager or see the upstream opencv [installation guides](https://docs.opencv.org/3.4/df/d65/tutorial_table_of_content_introduction.html).
+
+### Compiling OpenCV
+
+See the [upstream
+guides](https://docs.opencv.org/3.4/df/d65/tutorial_table_of_content_introduction.html)
+for compiling OpenCV for your platform. Make sure to compile from the
+correct release tag! We recommend including opencv_contrib and
+configuring your build with the same flags the travis build uses:
+
+```sh
+cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_PERF_TESTS=OFF \
+    -DBUILD_TESTS=OFF \
+    -DINSTALL_TESTS=OFF \
+    -DBUILD_DOCS=OFF \
+    -DBUILD_EXAMPLES=OFF \
+    -DBUILD_opencv_apps= \
+    -DWITH_IPP=OFF \
+    -DPYTHON_EXECUTABLE=OFF \
+    -DINSTALL_PYTHON_EXAMPLES=OFF \
+    -DWITH_LAPACK=ON \
+    -DWITH_EIGEN=ON \
+    -DBUILD_SHARED_LIBS=ON \
+    -DWITH_TBB=ON \
+    -DOPENCV_ENABLE_NONFREE=ON \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DOPENCV_EXTRA_MODULES_PATH=$PATH_TO_OPENCV_CONTRIB_MODULES \
+    $PATH_TO_OPENCV_SRC
+```
 ## Contrib modules
 The following modules require contrib installed:
  * bioinspired
@@ -12,74 +79,48 @@ The following modules require contrib installed:
  * phase_unwrapping
  * plot
 
-## Rust OpenCV bindings
+## OpenCV 2 support
 
-[![Build Status](https://travis-ci.org/twistedfall/opencv-rust.svg?branch=master)](https://travis-ci.org/twistedfall/opencv-rust)
+If you can't use opencv 3.4.6, the (no longer maintained) `0.2.4`
+version of this crate is known to work with opencv `2.4.7.13` (and probably other 2.4 versions).
 
-This is my shot at generating Rust bindings for OpenCV.
+## The binding strategy
 
-This is absolutely not ready for prime time.
+This crate works following the model of python and java's opencv
+wrappers - it parses the opencv C++ headers, generates a C interface
+to the C++ api, and wraps the C interface in Rust.
 
-Instead of binding the deprecated C-compatible interface, I chose to mimick the
-python and java wrappers: parsing C++ headers, generating a C interface to the 
-C++ api, and wrapping that in Rust.
-
-## Try it
-
-There are quite a few moving parts here. I'm working on MacOS, and Travis runs
-on Ubuntu 12.0.4, so these two are known to work. I expect any relatively 
-recent Linux to work fine, and I can't see anything serious preventing this
-to work under Windows if you are willing to spend a few hours on it.
-
-You will need OpenCV 2.4.11. Other 2.4 versions may work, feel free to try and
-tell me what happens. 3.0 will not work as is.
-
-You will also need python.
-
-[API Documentation](https://docs.rs/opencv)
-— or what I managed to extract from opencv widely inconsistent doxygen. At
-least you can see what has been ported or not to rust and how. You'll probably
-need to refer to the official [OpenCV C++ documentation](https://docs.opencv.org/3.4.6/).
-
-All the major modules in the C++ API
-are merged together in a huge cv:: namespace, leaving the client developper
-to manage its namespace by selectively including relevant headers. I instead
-made one rust module for each major OpenCV module. So C++ cv::Mat is 
-::opencv::core::Mat in Rust, etc.
+All the major modules in the C++ API are merged together in a huge
+`cv::` namespace. We instead made one rust module for each major
+OpenCV module. So, for example, C++ `cv::Mat` is `opencv::core::Mat`
+in this crate.
 
 The methods and field names have been snake_cased. Methods arguments with
-default value loose these default values, but they are reported in the
+default value lose these default values, but they are reported in the
 API documentation.
 
-Overloaded methods have been — manually — given a different name.
+Overloaded methods have been — manually — given different names.
 
-All methods return a Result, because... yeah, exceptions.
+All methods return a Result to hack around C++ exception handling.
 
-## API coverage
+Most of the API is covered, but for various reasons several modules
+are not yet implemented. If a missing module is near and dear to you,
+file an issue (or better, open a pull request!)
 
-I don't know or use the whole OpenCV library. I have deliberately let some
-modules out of these bindings in order to focus on parts I understand and/or
-have a need for. Due to the widely inconsistent use of C++ features and
-syntax in the library headers, adding them may be a matter of minutes or days,
-but we'll get there. PR are welcome.
+## Contributor's Guide
 
-Even in the covered modules, some classes or methods have been left out because
-they were referring to some C++ feature that the script did not understand. If
-we need them, we'll get them. Eventually. Please report them.
+The crate itself, as imported by users, consists of generated rust
+code in [src](src) committed to the repo. This way, users don't have
+to handle the code generation overhead in their builds. When
+developing this crate, you can test changes to the binding generation
+using `cargo build -vv --features buildtime_bindgen`. When changing
+the codegen, be sure to push changes to the generated code!
 
-And at some point, obviously, I want this to move to OpenCV 3.0.
+`hdr_parser.py` comes from opencv python/java generator. We've tried
+not to mess too much with this file, but had to make a few changes.
 
-## Hack it
-
-Please don't tell me how ugly these scripts look. Believe me, I am already
-painfully aware of this.
-
-hdr_parser.py comes from opencv python/java generator. I have tried not to mess
-too much with this file, but had to make a few changes.
-
-gen_rust is initially a copy of gen_java, also from
-the OpenCV generators, but is now so far from the initial stuff that I
-consider it an original work. 
+`gen_rust.py` is initially a copy of gen_java, also from the OpenCV
+generators, but it has drifted significantly from the original.
 
 The license for the original work is [MIT](https://opensource.org/licenses/MIT).
 


### PR DESCRIPTION
[Rendered](https://github.com/twistedfall/opencv-rust/blob/f75d1e0b12aab8f74921d21b28edaf7c735283b9/README.md)

I've also included some more detailed suggestions for how to get opencv set up, since many platforms do not have opencv packages which work with this crate, and the codegen seems to depend on certain compile flags.