### PR TITLE
Add test coverage for CV_32FC3 pixel read/writes

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Usage examples
+
+Some limited examples of how to use this crate are provided here.
+
+For more examples, refer to the hand-written tests at [/tests](/tests)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,28 @@
+//! Shared Test Utils
+
+use std::fmt::Debug;
+
+const F32_EPSILON: f32 = 1.0e-4;
+
+pub fn assert_almost_eq(left: f32, right: f32) {
+    assert!(
+        f32_almost_eq(left, right),
+        "{} is not approximately equal to {}.",
+        left,
+        right,
+    );
+}
+
+pub fn assert_is_err<T, E>(res: Result<T, E>)
+where
+    T: Debug,
+    E: Debug,
+{
+    if res.is_ok() {
+        assert!(false, "Expected {:?} to be an Error", res);
+    }
+}
+
+fn f32_almost_eq(left: f32, right: f32) -> bool {
+    (left - right).abs() < F32_EPSILON
+}


### PR DESCRIPTION
I had trouble figuring out how to read/write Mat pixels using the new `at` patterns wrt to `Vec*` structs, so adding some coverage showing it in action.

Also did some light test refactoring in the vicinity and added a test utils module for things like approximate equality checks between floats (since the previous `assert_eq!(some_float, some_float)` isn't reliable).

Also added an FYI readme in the examples dir pointing users to the `tests` folder, which has a lot of nice demonstrations of how various bits of the API works.