### PR TITLE
Add Mat pixel set functions

### DIFF
--- a/tests/mat.rs
+++ b/tests/mat.rs
@@ -34,7 +34,42 @@ fn mat_at_2d_CV_32FC1() {
     assert_almost_eq(*mat.at_2d::<f32>(0, 0).unwrap(), 1.23);
     *mat.at_2d_mut::<f32>(0, 0).unwrap() = 1.;
     assert_almost_eq(*mat.at_2d::<f32>(0, 0).unwrap(), 1.);
+}
+
+#[test]
+fn mat_at_with_wrong_type_is_err() {
+    // This will fail in non-debug builds since we don't check the type otherwise
+    let mat =
+        Mat::new_rows_cols_with_default(100, 100, core::CV_32FC1, Scalar::all(1.23)).unwrap();
     assert_is_err(mat.at::<i32>(0));
+
+}
+
+#[test]
+fn set_1d() {
+    let mut mat =
+        Mat::new_rows_cols_with_default(10, 10, core::CV_32FC1, Scalar::all(1.23)).unwrap();
+    mat.set::<f32>(0, 2.22).unwrap();
+    assert_almost_eq(*mat.at_2d::<f32>(0, 0).unwrap(), 2.22);
+}
+
+#[test]
+fn set_2d() {
+    let mut mat =
+        Mat::new_rows_cols_with_default(10, 10, core::CV_32FC1, Scalar::all(1.23)).unwrap();
+    mat.set_2d::<f32>(2, 3, 2.22).unwrap();
+    assert_almost_eq(*mat.at_2d::<f32>(2, 3).unwrap(), 2.22);
+}
+
+#[test]
+fn set_3d() {
+    let mut dims = VectorOfint::new();
+    dims.push(3);
+    dims.push(3);
+    dims.push(3);
+    let mut mat = Mat::new_nd_with_default(&dims, core::CV_32FC1, Scalar::all(1.23)).unwrap();
+    mat.set_3d::<f32>(0, 1, 2, 2.22);
+    assert_almost_eq(*mat.at_3d::<f32>(0, 1, 2).unwrap(), 2.22);
 }
 
 #[test]


### PR DESCRIPTION
This is a convenience wrapper around the awkward pointer-wrangling
usage patterns of `at_*_mut()` assignments.

Also changes various Mat methods to only perform a match_format
check when in debug builds for improved release performance.

The motivation behind this was a confusion I had trying to implement
mat element setting in some code. I had expected this to work:

```rust
#[test]
fn mat_at_2d_vec_type_modify_vec() {
    let mut mat =
        Mat::new_rows_cols_with_default(100, 100, core::CV_32FC3, Scalar::all(1.23)).unwrap();
    let pix = *mat.at_2d::<core::Vec3f>(0, 0).unwrap();
    assert_almost_eq(pix[0], 1.23);
    assert_almost_eq(pix[1], 1.23);
    assert_almost_eq(pix[2], 1.23);

    let mut pix = *mat.at_2d_mut::<core::Vec3f>(0, 0).unwrap();
    pix[0] = 1.1;
    
    let pix = *mat.at_2d::<core::Vec3f>(0, 0).unwrap();
    // Fails!
    assert_almost_eq(pix[0], 1.1);
    assert_almost_eq(pix[1], 1.23);
    assert_almost_eq(pix[2], 1.23);
}
```
But setting the vec elements in this way does not change the
data in the actual Mat. I _think_ this is because `Vec*` is `Copy`,
so an implicit copy is created when dereferencing the mutable
pointer given by `at_2d_mut()`

I suggest that we make it less likely other users run into this
by adding more obvious and concise methods for setting elements.
