### PR TITLE
Fix wrong condition for generating setter methods (Fix #84)

### DIFF
--- a/gen_rust.py
+++ b/gen_rust.py
@@ -3467,25 +3467,26 @@ class RustWrapperGenerator(object):
         self.classes[item.fullname] = item
         if not item.is_callback and not item.is_simple:
             for prop in item.props:
-                attrs = ["/ATTRGETTER"]
+                getter_attrs = ["/ATTRGETTER"]
                 prop_type = self.get_type_info(prop.ctype)
-                is_const = prop_type.is_const or prop_type.is_copy
-                if is_const:
-                    attrs.append("/C")
+
+                if prop_type.is_const or prop_type.is_copy:
+                    getter_attrs.append("/C")
                 read_func = self.add_decl(module, [
                     "{}.{}".format(item.fullname.replace("::", "."), prop.name),
                     prop.ctype,
-                    attrs,
+                    getter_attrs,
                     [],
                     None,
                     prop.comment
                 ])
-                if not read_func.is_ignored and not read_func.rv_type().is_ignored and not is_const:
-                    attrs = ["/ATTRSETTER"]
+
+                if not read_func.is_ignored and not read_func.rv_type().is_ignored and not prop_type.is_const:
+                    setter_attrs = ["/ATTRSETTER"]
                     self.add_decl(module, [
                         "{}.set_{}".format(item.fullname.replace("::", "."), prop.name),
                         "void",
-                        attrs,
+                        setter_attrs,
                         (
                             [prop_type.cpptype, "val", "", []],
                         ),


### PR DESCRIPTION
It fixes the issue that `gen_rust.py` script does not generate setter methods under some circumstances. It is due to improper condition to determine whether to generate a `set_*` method or not.

To state in details, the script decides `&self` or `&mut self` in setter method arguments by checking the var `is_const = (return type is const) or (return type is copyable)`. Then, in the continuing section, it checks if `is_const` is false to decide whether to generate a setter method. The pitfall is that this decision should not take (return type is copyable) into account, but `is_const` is not the case. The solution is done by fixing the conditions.

We may consider re-generating the built-in rust files after this patch. I'm not certain my OpenCV build is proper, so @twistedfall please cover that if possible.