### PR TITLE
do not delete DLLs when cleaning OUT_DIR

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -549,7 +549,12 @@ fn build_wrapper(opencv_header_dir: &PathBuf) -> Result<()> {
     eprintln!("=== Generating code in: {}", out_dir_as_str);
 
     for entry in glob(&format!("{}/*", out_dir_as_str))? {
-        let _ = fs::remove_file(entry?);
+        let path = entry?;
+        let path = match path.extension().unwrap_or_default().to_str() {
+            Some("dll") => continue,
+            _  => path
+        };
+        let _ = fs::remove_file(path);
     }
 
     let modules = get_modules(&opencv_dir.to_string_lossy())?;


### PR DESCRIPTION
As discussed in the linked issue, this leaves DLLs supplied by vcpkg intact in OUT_DIR so `cargo run` will be able to start the binary. Thanks!

Closes #97