### PR TITLE
Use MSVC 2017 compatible syntax

### DIFF
--- a/src_cpp/ocvrs_common.hpp
+++ b/src_cpp/ocvrs_common.hpp
@@ -40,11 +40,11 @@ struct Result_void {
 };
 
 template<typename T> inline Result<T> Ok(T result) {
-	return Result<T> { .error_code = 0, .error_msg = 0, .result = result };
+	return Result<T> { 0, 0, result };
 }
 
 inline Result_void Ok() {
-	return Result_void { .error_code = 0, .error_msg = 0 };
+	return Result_void { 0, 0 };
 }
 
 template<typename T> inline T Err(int code, const char* msg) {


### PR DESCRIPTION
Because we are using designated initializer feature at line 47 & 51 (after this patch), this code does not compile in VS2017, and the error message for that is not clear.

According to MS dev blog, this feature is introduced in VS 2019 16.1.
https://devblogs.microsoft.com/cppblog/c20-features-and-fixes-in-vs-2019-16-1-through-16-6/