### PR TITLE
Update DYLD_FALLBACK_LIBRARY_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ You need to set up the following environment variables to point to the installed
    found, e.g. for Xcode:
    
    ```  
-   export DYLD_FALLBACK_LIBRARY_PATH="$(xcode-select --print-path)/Toolchains/XcodeDefault.xctoolchain/usr/lib/"
+   export DYLD_FALLBACK_LIBRARY_PATH="$(xcode-select --print-path)/usr/lib/"
    ```
 
 ## Reporting issues


### PR DESCRIPTION
Update README.md with new path for DYLD_FALLBACK_LIBRARY_PATH.

On MacOS catalin 10.15.7 , the command line tools folder has changed. It no longer contains the Toolchains directory