### PR TITLE
Allow binding generator to work when default target != host target

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -59,7 +59,7 @@ static OUT_DIR: Lazy<PathBuf> = Lazy::new(|| PathBuf::from(env::var_os("OUT_DIR"
 static MANIFEST_DIR: Lazy<PathBuf> = Lazy::new(|| PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("Can't read CARGO_MANIFEST_DIR env var")));
 static SRC_DIR: Lazy<PathBuf> = Lazy::new(|| MANIFEST_DIR.join("src"));
 static SRC_CPP_DIR: Lazy<PathBuf> = Lazy::new(|| MANIFEST_DIR.join("src_cpp"));
-static HOST_TRIPLE: Lazy<String> = Lazy::new(||env::var("HOST_TRIPLE").expect("Unable to determine host triple"));
+static HOST_TRIPLE: Lazy<Option<String>> = Lazy::new(||env::var("HOST_TRIPLE").ok());
 
 static ENV_VARS: [&str; 18] = [
 	"OPENCV_HEADER_DIR",
@@ -818,8 +818,11 @@ fn main() -> Result<()> {
 		let cargo_bin = PathBuf::from(env::var_os("CARGO").unwrap_or_else(|| "cargo".into()));
 		let mut cargo = Command::new(cargo_bin);
 		// generator script is quite slow in debug mode, so we force it to be built in release mode
-		cargo.args(&["build", "--release", "--package", "opencv-binding-generator", "--bin", "binding-generator", "--target", &*HOST_TRIPLE])
+		cargo.args(&["build", "--release", "--package", "opencv-binding-generator", "--bin", "binding-generator"])
 			.env("CARGO_TARGET_DIR", &*OUT_DIR);
+		if let Some(host_triple) = HOST_TRIPLE.as_ref() {
+			cargo.args(&["--target", host_triple]);
+		}
 		println!("running: {:?}", &cargo);
 		Some(cargo.spawn()?)
 	} else {

--- a/build.rs
+++ b/build.rs
@@ -59,6 +59,7 @@ static OUT_DIR: Lazy<PathBuf> = Lazy::new(|| PathBuf::from(env::var_os("OUT_DIR"
 static MANIFEST_DIR: Lazy<PathBuf> = Lazy::new(|| PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("Can't read CARGO_MANIFEST_DIR env var")));
 static SRC_DIR: Lazy<PathBuf> = Lazy::new(|| MANIFEST_DIR.join("src"));
 static SRC_CPP_DIR: Lazy<PathBuf> = Lazy::new(|| MANIFEST_DIR.join("src_cpp"));
+static HOST_TRIPLE: Lazy<String> = Lazy::new(||env::var("HOST_TRIPLE").expect("Unable to determine host triple"));
 
 static ENV_VARS: [&str; 18] = [
 	"OPENCV_HEADER_DIR",
@@ -817,7 +818,7 @@ fn main() -> Result<()> {
 		let cargo_bin = PathBuf::from(env::var_os("CARGO").unwrap_or_else(|| "cargo".into()));
 		let mut cargo = Command::new(cargo_bin);
 		// generator script is quite slow in debug mode, so we force it to be built in release mode
-		cargo.args(&["build", "--release", "--package", "opencv-binding-generator", "--bin", "binding-generator"])
+		cargo.args(&["build", "--release", "--package", "opencv-binding-generator", "--bin", "binding-generator", "--target", &*HOST_TRIPLE])
 			.env("CARGO_TARGET_DIR", &*OUT_DIR);
 		println!("running: {:?}", &cargo);
 		Some(cargo.spawn()?)

--- a/build_generator.rs
+++ b/build_generator.rs
@@ -16,6 +16,7 @@ use super::{
 	file_copy_to_dir,
 	get_versioned_hub_dirs,
 	is_core_module,
+	HOST_TRIPLE,
 	MODULES,
 	OUT_DIR,
 	Result,
@@ -110,7 +111,7 @@ pub fn gen_wrapper(opencv_header_dir: &Path, generator_build: Option<Child>) -> 
 					let clang_stdlib_include_dir = (*clang_stdlib_include_dir).as_ref()
 						.and_then(|p| p.to_str())
 						.unwrap_or("None");
-					let mut bin_generator = Command::new(OUT_DIR.join("release/binding-generator"));
+					let mut bin_generator = Command::new(OUT_DIR.join(format!("{}/release/binding-generator", &*HOST_TRIPLE)));
 					bin_generator.arg(&*opencv_header_dir)
 						.arg(&*SRC_CPP_DIR)
 						.arg(&*OUT_DIR)

--- a/build_generator.rs
+++ b/build_generator.rs
@@ -111,7 +111,10 @@ pub fn gen_wrapper(opencv_header_dir: &Path, generator_build: Option<Child>) -> 
 					let clang_stdlib_include_dir = (*clang_stdlib_include_dir).as_ref()
 						.and_then(|p| p.to_str())
 						.unwrap_or("None");
-					let mut bin_generator = Command::new(OUT_DIR.join(format!("{}/release/binding-generator", &*HOST_TRIPLE)));
+					let mut bin_generator = match HOST_TRIPLE.as_ref() {
+						Some(host_triple) => Command::new(OUT_DIR.join(format!("{}/release/binding-generator", host_triple))),
+						None => Command::new(OUT_DIR.join("release/binding-generator")),
+					};
 					bin_generator.arg(&*opencv_header_dir)
 						.arg(&*SRC_CPP_DIR)
 						.arg(&*OUT_DIR)


### PR DESCRIPTION
Fixes https://github.com/twistedfall/opencv-rust/issues/197