### PR TITLE
Make errors public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub use crate::opencv::hub::*;
 #[macro_use]
 mod templ;
 
-mod error;
+pub mod error;
 mod opencv;
 mod manual;
 mod traits;


### PR DESCRIPTION
Hello, I was having trouble dealing with the Errors, since they aren't visible outside the library. I'm still new to rust, so might be missing something, about how you are supposed to handle them. But I think they should be public and because of that, this pull request. 

Changes:
- Made errors public so they are visible outside the library.