### PR TITLE
Add support for assign operator

### DIFF
--- a/binding-generator/src/func.rs
+++ b/binding-generator/src/func.rs
@@ -38,6 +38,7 @@ pub enum OperatorKind {
 	Mul,
 	Div,
 	Deref,
+	Assign,
 }
 
 impl OperatorKind {
@@ -61,6 +62,9 @@ impl OperatorKind {
 			}
 			"/" => {
 				OperatorKind::Div
+			}
+			"=" => {
+				OperatorKind::Assign
 			}
 			_ => {
 				OperatorKind::Unsupported
@@ -303,6 +307,9 @@ impl<'tu, 'ge> Func<'tu, 'ge> {
 		match self.kind() {
 			Kind::Constructor(cls) => {
 				cls.type_ref()
+			}
+			Kind::InstanceOperator(_, OperatorKind::Assign) => {
+				TypeRef::new(self.gen_env.resolve_type("void").expect("Can't resolve void type"), self.gen_env)
 			}
 			Kind::Function | Kind::InstanceMethod(..) | Kind::StaticMethod(..)
 			| Kind::ConversionMethod(..) | Kind::GenericInstanceMethod(..) | Kind::GenericFunction
@@ -639,6 +646,9 @@ impl Element for Func<'_, '_> {
 						} else {
 							"try_deref_mut".into()
 						}
+					}
+					OperatorKind::Assign => {
+						"assign".into()
 					}
 				}
 			} else {

--- a/binding-generator/src/string_ext.rs
+++ b/binding-generator/src/string_ext.rs
@@ -210,6 +210,7 @@ impl StringExt for String {
 		self.replace_in_place("+", "A");
 		self.replace_in_place("-", "S");
 		self.replace_in_place("/", "D");
+		self.replace_in_place("=", "As");
 	}
 }
 

--- a/binding-generator/src/writer/rust_native/func.rs
+++ b/binding-generator/src/writer/rust_native/func.rs
@@ -11,7 +11,7 @@ use crate::{
 	Element,
 	Field,
 	Func,
-	func::Kind,
+	func::{Kind, OperatorKind},
 	FunctionTypeHint,
 	get_debug,
 	IteratorExt,
@@ -196,6 +196,9 @@ fn cpp_call_invoke(f: &Func) -> String {
 		Kind::FieldAccessor(class) if f.type_hint() == FunctionTypeHint::FieldSetter => {
 			cpp_method_call_name(&class, DefaultElement::cpp_localname(f).as_ref()).into()
 		}
+		Kind::InstanceOperator(_, OperatorKind::Assign) => {
+			"*instance".into()
+		}
 		Kind::InstanceMethod(class) | Kind::FieldAccessor(class) | Kind::GenericInstanceMethod(class)
 		| Kind::ConversionMethod(class) | Kind::InstanceOperator(class, ..) => {
 			cpp_method_call_name(&class, f.cpp_localname().as_ref()).into()
@@ -229,6 +232,8 @@ fn cpp_call_invoke(f: &Func) -> String {
 		} else {
 			&FIELD_READ_TPL
 		}
+	} else if let Kind::InstanceOperator(_, OperatorKind::Assign) = f.kind() {
+		&FIELD_WRITE_TPL
 	} else if return_type.is_void() {
 		&VOID_TPL
 	} else {


### PR DESCRIPTION
Assign operator may be useful, for example, apply MatExpr to existing Mat instead of making new copy.