### PR TITLE
Added necessary VectorOfVec3f, VectorOfVectorOfVec3f type definitions

### DIFF
--- a/binding-generator/src/settings.rs
+++ b/binding-generator/src/settings.rs
@@ -1030,6 +1030,8 @@ pub static GENERATOR_MODULE_TWEAKS: Lazy<HashMap<&str, ModuleTweak>> = Lazy::new
 			"std::vector<std::vector<cv::Point3i>>",
 			"std::vector<cv::Point3d>",
 			"std::vector<std::vector<cv::Point3d>>",
+			"std::vector<cv::Vec3f>",
+			"std::vector<std::vector<cv::Vec3f>>",
 		],
 		..Default::default()
 	},


### PR DESCRIPTION
Definitions are required by opencv 4.x  `calibrate_camera` method.