### PR TITLE
Don't use NOTICE log level in cmake

### DIFF
--- a/build/cmake_probe.rs
+++ b/build/cmake_probe.rs
@@ -55,10 +55,7 @@ impl<'r> CmakeProbe<'r> {
 	fn make_cmd(&self) -> Command {
 		let mut out = Command::new(&self.cmake_bin);
 		out.current_dir(&self.build_dir)
-			.args(&[
-				"--log-level=NOTICE",
-				"-S"
-			])
+			.args(&["-S"])
 			.arg(&self.src_dir)
 			.arg(format!("-DOCVRS_PACKAGE_NAME={}", &self.package_name));
 

--- a/ci/install-windows-vcpkg.sh
+++ b/ci/install-windows-vcpkg.sh
@@ -3,6 +3,7 @@
 set -vex
 
 export VCPKG_ROOT="$HOME/build/vcpkg"
+rm -rf "VCPKG_ROOT"
 if [[ -e "$VCPKG_ROOT" && ! -e "$VCPKG_ROOT/.git" ]]; then
 	rm -rf "$VCPKG_ROOT"
 fi

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -4,8 +4,8 @@ cmake_minimum_required(VERSION 3.0)
 
 find_package(${OCVRS_PACKAGE_NAME} REQUIRED)
 
-message(NOTICE "OCVRS_INCLUDE_DIRS:${OpenCV_INCLUDE_DIRS}")
-message(NOTICE "OCVRS_VERSION:${OpenCV_VERSION}")
+message("OCVRS_INCLUDE_DIRS:${OpenCV_INCLUDE_DIRS}")
+message("OCVRS_VERSION:${OpenCV_VERSION}")
 
 include_directories(${OpenCV_INCLUDE_DIRS})
 add_executable(ocvrs_probe ocvrs_probe.cpp)


### PR DESCRIPTION
NOTICE was introduced in 3.15 so log messages that cmake_probe.rs
uses to parse the location and version of the system OpenCV
installation end up malformed in older CMake versions. This commit
drops the log level. Without a log-level `message`, the log level
is something similar to NOTICE anyways.

Fixes twistedfall/opencv-rust#253