### PR TITLE
Make OpenCV modules available as crate features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,21 @@ once_cell = "1.0"
 [features]
 clang-runtime = ["clang/runtime"]
 docs-only = []
+default = ["all-modules"]
 
 # OpenCV modules
+all-modules = [
+    "alphamat", "aruco", "barcode", "bgsegm", "bioinspired", "calib3d", "ccalib", "cudaarithm",
+    "cudabgsegm", "cudacodec", "cudafeatures2d", "cudafilters", "cudaimgproc", "cudaobjdetect",
+    "cudaoptflow", "cudastereo", "cudawarping", "cvv", "dnn", "dnn_superres", "dpm", "face",
+    "features2d", "flann", "freetype", "fuzzy", "gapi", "hdf", "hfs", "highgui", "img_hash",
+    "imgcodecs", "imgproc", "intensity_transform", "line_descriptor", "mcc", "ml", "objdetect",
+    "optflow", "ovis", "phase_unwrapping", "photo", "plot", "quality", "rapid", "rgbd", "saliency",
+    "sfm", "shape", "stereo", "stitching", "structured_light", "superres", "surface_matching",
+    "text", "tracking", "video", "videoio", "videostab", "viz", "xfeatures2d", "ximgproc",
+    "xobjdetect", "xphoto", "wechat_qrcode",
+]
+
 alphamat = []
 aruco = []
 barcode = []
@@ -69,7 +82,17 @@ bgsegm = []
 bioinspired = []
 calib3d = []
 ccalib = []
-core = []
+cudaarithm = []
+cudabgsegm = []
+cudacodec = []
+cudafeatures2d = []
+cudafilters = []
+cudaimgproc = []
+cudaobjdetect = []
+cudaoptflow = []
+cudastereo = []
+cudawarping = []
+cvv = []
 dnn = []
 dnn_superres = []
 dpm = []
@@ -78,6 +101,8 @@ features2d = []
 flann = []
 freetype = []
 fuzzy = []
+gapi = []
+hdf = []
 hfs = []
 highgui = []
 img_hash = []
@@ -89,6 +114,7 @@ mcc = []
 ml = []
 objdetect = []
 optflow = []
+ovis = []
 phase_unwrapping = []
 photo = []
 plot = []
@@ -109,21 +135,11 @@ video = []
 videoio = []
 videostab = []
 viz = []
-wechat_qrcode = []
 xfeatures2d = []
 ximgproc = []
 xobjdetect = []
 xphoto = []
-
-default = [
-    "alphamat", "aruco", "barcode", "bgsegm", "bioinspired", "calib3d", "ccalib", "core",
-    "dnn", "dnn_superres", "dpm", "face", "features2d", "flann", "freetype", "fuzzy", "hfs",
-    "highgui", "img_hash", "imgcodecs", "imgproc", "intensity_transform", "line_descriptor", "mcc",
-    "ml", "objdetect", "optflow", "phase_unwrapping", "photo", "plot", "quality", "rapid", "rgbd",
-    "saliency", "sfm", "shape", "stereo", "stitching", "structured_light", "superres",
-    "surface_matching", "text", "tracking", "video", "videoio", "videostab", "viz", "wechat_qrcode",
-    "xfeatures2d", "ximgproc", "xobjdetect", "xphoto"
-]
+wechat_qrcode = []
 
 [build-dependencies]
 binding-generator = { package = "opencv-binding-generator", version = "0.32.0", path = "binding-generator" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,70 @@ once_cell = "1.0"
 clang-runtime = ["clang/runtime"]
 docs-only = []
 
+# OpenCV modules
+alphamat = []
+aruco = []
+barcode = []
+bgsegm = []
+bioinspired = []
+calib3d = []
+ccalib = []
+core = []
+dnn = []
+dnn_superres = []
+dpm = []
+face = []
+features2d = []
+flann = []
+freetype = []
+fuzzy = []
+hfs = []
+highgui = []
+img_hash = []
+imgcodecs = []
+imgproc = []
+intensity_transform = []
+line_descriptor = []
+mcc = []
+ml = []
+objdetect = []
+optflow = []
+phase_unwrapping = []
+photo = []
+plot = []
+quality = []
+rapid = []
+rgbd = []
+saliency = []
+sfm = []
+shape = []
+stereo = []
+stitching = []
+structured_light = []
+superres = []
+surface_matching = []
+text = []
+tracking = []
+video = []
+videoio = []
+videostab = []
+viz = []
+wechat_qrcode = []
+xfeatures2d = []
+ximgproc = []
+xobjdetect = []
+xphoto = []
+
+default = [
+    "alphamat", "aruco", "barcode", "bgsegm", "bioinspired", "calib3d", "ccalib", "core",
+    "dnn", "dnn_superres", "dpm", "face", "features2d", "flann", "freetype", "fuzzy", "hfs",
+    "highgui", "img_hash", "imgcodecs", "imgproc", "intensity_transform", "line_descriptor", "mcc",
+    "ml", "objdetect", "optflow", "phase_unwrapping", "photo", "plot", "quality", "rapid", "rgbd",
+    "saliency", "sfm", "shape", "stereo", "stitching", "structured_light", "superres",
+    "surface_matching", "text", "tracking", "video", "videoio", "videostab", "viz", "wechat_qrcode",
+    "xfeatures2d", "ximgproc", "xobjdetect", "xphoto"
+]
+
 [build-dependencies]
 binding-generator = { package = "opencv-binding-generator", version = "0.32.0", path = "binding-generator" }
 cc = { version = "1.0", features = ["parallel"] }

--- a/README.md
+++ b/README.md
@@ -217,10 +217,8 @@ The following variables are rarely used, but you might need them under some circ
     * vcpkg
 
 * `OPENCV_MODULE_WHITELIST` and `OPENCV_MODULE_BLACKLIST`
-  Comma separated lists that affect modules that get their bindings generated. Setting whitelist will only
-  generate the specified modules, setting blacklist will exclude the specified modules from generation. If the
-  same module is specified in both list it will be excluded (i.e. blacklist has precedence). E.g.
-  "core,dnn,features2d" .
+  Not used anymore. These used to be used to select modules that get their binding generated. We have switched to
+  using cargo features for module selection. Please see the section on features to learn how to switch.
 
 The following variables affect the building the of the `opencv` crate, but belong to external components:
 
@@ -258,6 +256,10 @@ The following variables affect the building the of the `opencv` crate, but belon
 * `clang-runtime` - enables the runtime detection of libclang (`runtime` feature of `clang-sys`). Useful as a
   workaround for when your dependencies (like `bindgen`) pull in `clang-sys` with hard `runtime` feature.
 * `docs-only` - internal usage, for building docs on [docs.rs](https://docs.rs/opencv)
+* `all-modules` - include all OpenCV modules. This is the default.
+* If you don't want to include all modules you can specify the module name as a feature. Make sure to include
+  all dependent modules, e.g.
+  `opencv = { version = ..., default-features = false, features = ["calib3d", "features2d", "flann"]}`.
 
 ## API details
 

--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,6 @@ use std::{
 	ffi::OsStr,
 	fs::File,
 	io::{BufRead, BufReader},
-	iter::FromIterator,
 	path::{Path, PathBuf},
 	process::Command,
 };
@@ -155,9 +154,9 @@ fn make_modules(opencv_dir: &Path) -> Result<()> {
 			.map(|e| e.trim())
 			.collect::<HashSet<_>>()
 		);
-	let feature_whitelist: HashSet<String> = HashSet::from_iter(env::vars_os().filter_map(|(k, _)|
+	let feature_whitelist = env::vars_os().filter_map(|(k, _)|
 		k.to_str().and_then(|s| s.strip_prefix("CARGO_FEATURE_").map(str::to_lowercase))
-	));
+	).collect::<HashSet<_>>();
 
 	let env_blacklist = env::var("OPENCV_MODULE_BLACKLIST").ok();
 	let env_blacklist = env_blacklist.as_ref()


### PR DESCRIPTION
Use cargo features to select modules.

This is addressing https://github.com/twistedfall/opencv-rust/issues/297. The biggest issue is not breaking existing builds, so we have to respect `OPENCV_MODULES_(WHITELIST|BLACKLIST)`.  Since existing packages do not have features defined this has to keep functioning even with no features. There are two options here, either make it function like a whitelist where no whitelist means keep everything or declare `default` feature with everything included. The first option wouldn't work because features have to be additive. Otherwise adding a dependency with feature `core` would all of the sudden make a dependency with no features stop compiling.

A module that is required but not found will not be compiled. This allows default features to have every possible module and not worry about what's installed on the machine.