### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ use opencv::prelude::*;
 
 ### Linux
 
+#### Arch Linux:
+
+OpenCV package in Arch is suitable for this.
+
+`pacman -S clang qt5-base opencv`
+
+#### Ubuntu:
+
+`sudo apt install libopencv-dev clang libclang-dev`
+
+#### Other Linux:
 You have several options of getting the OpenCV library:
 
 * install it from the repository, make sure to install `-dev` packages because they contain headers necessary


### PR DESCRIPTION
Made description more explicit as in https://github.com/paritytech/metadata-portal
So somebody who got compilation error and opening creates.io description can see simple solition for most widely used systems,
e.q. it's called libopencv-dev on ubuntu, not opencv-dev