### PR TITLE
Add support for DirectX Interop on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,17 @@ once_cell = "1"
 # version 0.8.20 doesn't contain the deficiency mentioned in https://deps.rs/crate/opencv/0.59.0#vulnerabilities
 rgb = { version = "0.8.20", features = ["argb"], optional = true }
 
+[dependencies.windows]
+version = "0.54"
+optional = true
+features = [
+	"Win32_Foundation",
+	"Win32_Graphics_Direct3D",
+	"Win32_Graphics_Direct3D11",
+	"Win32_Graphics_Dxgi_Common",
+	"Win32_System_WinRT_Direct3D11",
+]
+
 [build-dependencies]
 opencv-binding-generator = { version = "0.84.0", path = "binding-generator" }
 cc = { version = ">=1.0.83", features = ["parallel"] }
@@ -176,6 +187,7 @@ cudaoptflow = []
 cudastereo = ["calib3d"]
 cudawarping = []
 cvv = []
+directx = ["windows"] # TODO only enable to windows
 dnn = []
 dnn_superres = []
 dpm = []

--- a/src/manual/core.rs
+++ b/src/manual/core.rs
@@ -1,5 +1,7 @@
 pub use affine3::*;
 pub use data_type::*;
+#[cfg(feature = "directx")]
+pub use directx::*;
 pub use input_output_array::*;
 pub use mat::*;
 pub use mat_ops::*;
@@ -18,6 +20,8 @@ pub use CV_MAKETYPE as CV_MAKE_TYPE;
 
 mod affine3;
 mod data_type;
+#[cfg(feature = "directx")]
+mod directx;
 mod gpumat;
 mod input_output_array;
 mod mat;

--- a/src/manual/core/directx.rs
+++ b/src/manual/core/directx.rs
@@ -1,0 +1,44 @@
+use crate::{
+	core::{self, _OutputArrayTraitConst},
+	error::Result,
+	sys::{self, ResultVoid},
+	traits::OpenCVType,
+};
+use std::ffi::c_void;
+
+use windows::{
+	core::Interface,
+	Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11Texture2D},
+};
+
+pub unsafe fn convert_from_d3d11_texture_2d(texture: &ID3D11Texture2D, dst: &mut impl core::ToOutputArray) -> Result<()> {
+	return_send!(via ocvrs_return);
+	output_array_arg!(dst);
+	cv_directx_convertFromD3D11Texture2D_ID3D11Texture2DX_const__OutputArrayR(
+		texture.as_raw(),
+		dst.as_raw__OutputArray(),
+		ocvrs_return.as_mut_ptr(),
+	);
+	return_receive!(unsafe ocvrs_return => ret);
+	let ret = ret.into_result()?;
+	Ok(ret)
+}
+
+pub unsafe fn initialize_context_from_d3d11_device(device: &ID3D11Device) -> Result<core::Context> {
+	return_send!(via ocvrs_return);
+	cv_directx_ocl_initializeContextFromD3D11Device_ID3D11Device2DX(device.as_raw(), ocvrs_return.as_mut_ptr());
+	return_receive!(unsafe ocvrs_return => ret);
+	let ret = ret.into_result()?;
+	let ret = unsafe { core::Context::opencv_from_extern(ret) };
+	Ok(ret)
+}
+
+extern "C" {
+	fn cv_directx_convertFromD3D11Texture2D_ID3D11Texture2DX_const__OutputArrayR(
+		ptr: *const c_void,
+		dst: *const c_void,
+		ret: *mut ResultVoid,
+	);
+
+	fn cv_directx_ocl_initializeContextFromD3D11Device_ID3D11Device2DX(ptr: *mut c_void, ret: *mut sys::Result<*mut c_void>);
+}

--- a/src_cpp/manual-core.cpp
+++ b/src_cpp/manual-core.cpp
@@ -78,4 +78,20 @@ extern "C" {
 	void cv_Vec18d_input_array(cv::Vec<double, 18>* instance, Result<void*>* ocvrs_return) { return ocvrs_input_array(instance, ocvrs_return); }
 	void cv_Vec18d_output_array(cv::Vec<double, 18>* instance, Result<void*>* ocvrs_return) { return ocvrs_output_array(instance, ocvrs_return); }
 	void cv_Vec18d_input_output_array(cv::Vec<double, 18>* instance, Result<void*>* ocvrs_return) { return ocvrs_input_output_array(instance, ocvrs_return); }
+
+	void cv_directx_convertFromD3D11Texture2D_ID3D11Texture2DX_const__OutputArrayR(void* ptr, cv::_OutputArray dst, ResultVoid* ocvrs_return) {
+		try {
+			// TODO should only enable on Windows
+			cv::directx::convertFromD3D11Texture2D((ID3D11Texture2D*)ptr, dst);
+			Ok(ocvrs_return);
+		} OCVRS_CATCH(ocvrs_return);
+	}
+
+	void cv_directx_ocl_initializeContextFromD3D11Device_ID3D11Device2DX(void* ptr, Result<cv::ocl::Context*>* ocvrs_return) {
+		try {
+			// TODO should only enable on Windows
+			cv::ocl::Context ret = cv::directx::ocl::initializeContextFromD3D11Device((ID3D11Device*)ptr);
+			Ok(new cv::ocl::Context(ret), ocvrs_return);
+		} OCVRS_CATCH(ocvrs_return);
+	}
 }


### PR DESCRIPTION
Hi and thanks for the library! This PR aims to add support for OpenCV's [DirectX interoperability API](https://github.com/opencv/opencv/blob/625eebad54a34a7bdad6812f3e9ec050a1b3adc5/modules/core/include/opencv2/core/directx.hpp) with help of `windows` crate when building on Windows.

As a first step, I was able to add a rudimentary manual support for a couple of functions, and verified that it works in scope of another project (planning to add a minimal example here later). I suspect there should be a way to make bindings-generator to implement these APIs automatically; for example, `get_type_from_d3d_format` function is already there. It seems that the main reason the rest of `cv::directx` namespace are not picked up is that DirectX types get excluded during entity discover phase. However, I'm not sure what is the best way of making them included. I'd appreciate any help/pointers on this!
