### PR TITLE
Return an error when the parsing has failed

### DIFF
--- a/build/library.rs
+++ b/build/library.rs
@@ -226,14 +226,14 @@ impl Library {
 			let mut cargo_metadata = Vec::with_capacity(64);
 			let include_paths: Vec<_> = include_paths.iter().map(PathBuf::from).collect();
 
-			let version = Self::version_from_include_paths(&include_paths);
+			let version = Self::version_from_include_paths(&include_paths).ok_or("could not get versions from header files")?;
 
 			cargo_metadata.extend(Self::process_link_paths(Some(link_paths), vec![], None));
 			cargo_metadata.extend(Self::process_link_libs(Some(link_libs), vec![], None));
 
 			Ok(Self {
 				include_paths,
-				version: version.unwrap_or_else(|| Version::new(0, 0, 0)),
+				version,
 				cargo_metadata,
 			})
 		} else {


### PR DESCRIPTION
Hi maintainers! I encountered an issue while using this library, and tried to fix it.
I'm sorry if this PR doesn't follow some rules, as I'm very new to contribute to OSSes.
Please notify me if there's any missing information 🙏 
Thank you!

***

Currently, `probe_from_paths` returns empty `Version` (i.e., `0.0.0`) when it fails to guess the OpenCV version from header files.
It causes an "Unsupported OpenCV version" error.

I saw the error because the function could not find `version.hpp` at the expected location.
The root cause was the misconfiguration of include paths.

Instead, it will be more user-friendly if it explicitly reports an error.