### PR TITLE
feat: allow custom arguments for clang

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ The following variables affect the building the of the `opencv` crate, but belon
   `*.dll`s next to your binary. Be sure to specify paths in UNIX style (/C/Program Files/Dir) because colon
   in `PATH` might be interpreted as the entry separator. Summary [here](https://stackoverflow.com/a/6546427).
 
+* `OPENCV_CLANG_ARGS`
+  Allow custom arguments for generating and parsing code with clang, see the [documentation for clang arguments](https://docs.rs/clang/latest/clang/struct.Parser.html#method.arguments).
+
 * clang crate environment variables
   See crate's [README](https://github.com/KyleMayes/clang-sys/blob/master/README.md#environment-variables)
 

--- a/binding-generator/Cargo.toml
+++ b/binding-generator/Cargo.toml
@@ -18,6 +18,7 @@ dunce = "1"
 once_cell = "1" # replace with std::sync::OnceLock when MSRV is 1.70
 percent-encoding = { version = "2", default-features = false }
 regex = "1"
+shlex = { version = "1.3", default-features = false }
 
 [features]
 clang-runtime = ["clang/runtime", "clang-sys/runtime"]

--- a/binding-generator/src/generator.rs
+++ b/binding-generator/src/generator.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use clang::diagnostic::{Diagnostic, Severity};
 use clang::{Clang, Entity, EntityKind, Index};
 use dunce::canonicalize;
+use shlex::Shlex;
 
 use crate::type_ref::{CppNameStyle, FishStyle, TypeRef, TypeRefKind};
 use crate::typedef::NewTypedefResult;
@@ -435,10 +436,10 @@ impl Generator {
 		// need to have c++14 here because VS headers contain features that require it
 		args.push("-std=c++14".into());
 		// allow us to use some custom clang args
-		let clang_args = env::var_os("OPENCV_CLANG_ARGS").unwrap_or_default();
-		clang_args.to_string_lossy().split_whitespace().map(String::from).for_each(|i| {
-			args.push(i.into());
-		});
+		if let Some(clang_arg_str) = env::var_os("OPENCV_CLANG_ARGS") {
+			let clang_arg = clang_arg_str.to_str().expect("Try to get OPENCV_CLANG_ARGS failed.");
+			Shlex::new(clang_arg).into_iter().for_each(|i| args.push(i.into()))
+		}
 		args
 	}
 

--- a/binding-generator/src/generator.rs
+++ b/binding-generator/src/generator.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::env;
 use std::fs::File;
 use std::io::BufReader;
 use std::ops::ControlFlow;
@@ -433,6 +434,11 @@ impl Generator {
 		args.push("-includeocvrs_common.hpp".into());
 		// need to have c++14 here because VS headers contain features that require it
 		args.push("-std=c++14".into());
+		// allow us to use some custom clang args
+		let clang_args = env::var_os("OPENCV_CLANG_ARGS").unwrap_or_default();
+		clang_args.to_string_lossy().split_whitespace().map(String::from).for_each(|i| {
+			args.push(i.into());
+		});
 		args
 	}
 


### PR DESCRIPTION
For openharmony,  we use `/path/to/ndk/clang` to build project, but it doesn't include basic arguments.

For example, for `aarch64-unknown-linux-ohos` we need to add  `-target aarch64-linux-ohos --sysroot=${OHOS_NDK_HOME}/native/sysroot -D__MUSL__` based with [rust-book](https://doc.rust-lang.org/rustc/platform-support/openharmony.html).

When we compile the corresponding modules on mac/win, the lack of these arguments will cause the build to fail, so we need add those arguments to `Index`.

