### PR TITLE
Support toolchain and custom args for CMake

### DIFF
--- a/build/cmake_probe.rs
+++ b/build/cmake_probe.rs
@@ -110,6 +110,7 @@ pub struct CmakeProbe<'r> {
 	package_name: &'r str,
 	toolchain: Option<&'r Path>,
 	is_release: bool,
+	args: Option<&'r str>,
 }
 
 impl<'r> CmakeProbe<'r> {
@@ -120,6 +121,7 @@ impl<'r> CmakeProbe<'r> {
 		package_name: &'r str,
 		toolchain: Option<&'r Path>,
 		is_release: bool,
+		args: Option<&'r str>,
 	) -> Self {
 		Self {
 			cmake_bin: cmake_bin.unwrap_or_else(|| "cmake".into()),
@@ -128,6 +130,7 @@ impl<'r> CmakeProbe<'r> {
 			package_name,
 			toolchain,
 			is_release,
+			args,
 		}
 	}
 
@@ -161,6 +164,9 @@ impl<'r> CmakeProbe<'r> {
 			out.arg("-DCMAKE_BUILD_TYPE=Release");
 		} else {
 			out.arg("-DCMAKE_BUILD_TYPE=Debug");
+		}
+		if let Some(args) = &self.args {
+			out.args(args.split(' '));
 		}
 		out
 	}

--- a/build/library.rs
+++ b/build/library.rs
@@ -341,6 +341,8 @@ impl Library {
 		cmake_bin: Option<&Path>,
 		ninja_bin: Option<&Path>,
 	) -> Result<Self> {
+		let toolchain_var = env::var_os("OPENCV_CMAKE_TOOLCHAIN_FILE").map(PathBuf::from);
+		let toolchain = toolchain.or_else(|| toolchain_var.as_ref().map(PathBuf::as_path));
 		eprintln!(
 			"=== Probing OpenCV library using cmake{}",
 			toolchain.map_or_else(|| "".to_string(), |tc| format!(" with toolchain: {}", tc.display()))
@@ -348,6 +350,7 @@ impl Library {
 
 		let src_dir = MANIFEST_DIR.join("cmake");
 		let package_name = PackageName::cmake();
+		let args = env::var_os("OPENCV_CMAKE_ARGS");
 		let cmake = CmakeProbe::new(
 			env::var_os("OPENCV_CMAKE_BIN")
 				.map(PathBuf::from)
@@ -357,6 +360,7 @@ impl Library {
 			package_name.as_ref(),
 			toolchain,
 			env::var_os("PROFILE").is_some_and(|p| p == "release"),
+			args.as_ref().and_then(|p| p.to_str()),
 		);
 		let mut probe_result = cmake
 			.probe_ninja(ninja_bin)


### PR DESCRIPTION
As #683 says,  we provide environment variables `OPENCV_CMAKE_TOOLCHAIN_FILE` and `OPENCV_CMAKE_ARGS` so we can pass more customizable options to CMake.

I'm new to Rust so please correct me if you find any mistakes. Thanks!