### PR TITLE
build: add `opencv5` to the list of pkgconfig names

### DIFF
--- a/build/library.rs
+++ b/build/library.rs
@@ -35,7 +35,7 @@ impl PackageName {
 	pub fn pkg_config() -> Vec<Cow<'static, str>> {
 		Self::env()
 			.or_else(Self::env_pkg_config)
-			.map_or_else(|| vec!["opencv4".into(), "opencv".into()], |env_name| vec![env_name.into()])
+			.map_or_else(|| vec!["opencv5".into(), "opencv4".into(), "opencv".into()], |env_name| vec![env_name.into()])
 	}
 
 	pub fn cmake() -> Cow<'static, str> {


### PR DESCRIPTION
On Arch Linux, the pkgconfig file for opencv5 is called "opencv5.pc". This seems like a vanilla upstream filename.

See https://archlinux.org/packages/extra/x86_64/opencv/ for the package details.