### PR TITLE
Fix cross compilation of binding-generator

### DIFF
--- a/binding-generator/src/generator.rs
+++ b/binding-generator/src/generator.rs
@@ -383,7 +383,7 @@ impl Drop for Generator {
 
 impl Generator {
 	pub fn new(opencv_include_dir: &Path, additional_include_dirs: &[&Path], src_cpp_dir: &Path) -> Self {
-		let clang_bin = clang_sys::support::Clang::find(None, &[]).expect("Can't find clang binary");
+		let clang_bin = clang_sys::support::Clang::find(None, &["-nostdlibinc".to_string()]).expect("Can't find clang binary");
 		let mut clang_include_dirs = clang_bin.cpp_search_paths.unwrap_or_default();
 		for additional_dir in additional_include_dirs {
 			match canonicalize(additional_dir) {


### PR DESCRIPTION
Pass -nostdlibinc to clang so that host path will not be included, as they will break compilation with target SDK toolchain:
  === Using OpenCV headers from: /opt/sdk/dev/sysroots/armv8a-tq-linux/usr/include/opencv4
  === Clang: clang version 22.1.8
  === Clang command line args: [
      "-isystem/opt/sdk/dev/sysroots/x86_64-tqsdk-linux/usr/lib/clang/22/include",
      "-isystem/usr/local/include",
      "-isystem/usr/include",
  [...]

Please also consider adding this as a fix to 0.99.1. Currently build breaks on master for systems with both openvc5 and opencv4 installed, but the project requiring opencv4.